### PR TITLE
Use Class ID in Upgrades Pane

### DIFF
--- a/looty/src/main/scala/looty/views/loot/UpgradesPane.scala
+++ b/looty/src/main/scala/looty/views/loot/UpgradesPane.scala
@@ -76,7 +76,7 @@ class UpgradesPane(
       val items = inventory.allItems(Some(name)).toList
 
       chars.find(_.name =?= name).foreach { charInfo =>
-        val cls = CharClasses.allMap(charInfo.`class`)
+        val cls = CharClasses.allIdMap(charInfo.`classId`)
         val pAttrs = PassiveSkillTreeHelp.hashesToAttributes(passives.hashes)
         val attrs = cls.startingAttributes.reduceWith(pAttrs)(_ + _)
         displayLevelAndAttributes(charInfo.level.toInt, attrs)


### PR DESCRIPTION
Ascendancy reports subclasses in a way that changes the actual class name in the character info object ("Witch" becomes "Necromancer" etc). The class ID is unchanged, so it should be possible to use it instead.