### PR TITLE
Chrome ext fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,20 @@ looty/target/web/public/
 Load it with about:debugging
 
 
- 
+##
+Newer todos:
+- Card Views
+  - allows seeing gems / uniques etc as items in a 2d grid of cells
+    - each cell is like a card
+  - beefs up the map view
+    - though replace the map view with an atlas view
+
+- Quick comparision of item to all other items in the stash
+  - allows for seeing how the item stacks up to all other items
+    - maybe use something like spark-line bar charts
+    - will be great for ssf
+
+
 
 
 ##Statement of Inspiration

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Quoted from Steve Yegge's [Excellent Blog Post](http://steve-yegge.blogspot.com/
 ## Developer Log
 ```code
 # Version History
+## 0.2.1.77 (2019-11-18)
+Chrome extension works again, hurray
+
+## 0.2.1.76 (2019-10-30)
+firefox review placation
+
 ## 0.2.1.75 (2019-05-01)
 Jewel Support
 

--- a/looty/src/main/public/manifest.json
+++ b/looty/src/main/public/manifest.json
@@ -16,7 +16,7 @@
     "default_popup" : "popup.html"
   },
 
-  "content_security_policy": "object-src 'self'; script-src 'self' https://ssl.google-analytics.com 'unsafe-eval'",
+  "content_security_policy": "object-src 'self'; script-src 'self' 'unsafe-eval'",
 
-  "permissions": ["https://www.pathofexile.com/*", "https://webcdn.pathofexile.com/*", "http://www.pathofexile.com/*", "http://webcdn.pathofexile.com/*", "clipboardWrite", "clipboardRead", "storage", "unlimitedStorage"]
+  "permissions": ["https://www.pathofexile.com/*", "https://webcdn.pathofexile.com/*", "clipboardWrite", "clipboardRead", "storage", "unlimitedStorage"]
 }

--- a/looty/src/main/public/manifest.json
+++ b/looty/src/main/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Looty! Stash search for Path of Exile",
-  "version": "0.2.1.76",
+  "version": "0.2.1.77",
 
   "description": "Looty! Helps you quickly find items by their stats or name in large Path of Exile stashes.",
 

--- a/looty/src/main/scala/looty/poeapi/PoeRpcs.scala
+++ b/looty/src/main/scala/looty/poeapi/PoeRpcs.scala
@@ -90,7 +90,7 @@ object PoeRpcs {
   //We send all rpc calls through a queue, since GGG throttles
   //the calls to their api we will need to re-attempt certain
   //calls on throttle failures
-  def enqueue[A](url: String, params: js.Any, reqType: HttpRequestType = HttpRequestTypes.Post): Future[A] = {
+  def enqueue[A](url: String, params: js.Any, reqType: HttpRequestType = HttpRequestTypes.Get): Future[A] = {
     val qi = QueueItem(url, params, reqType)
     Q.addToQueue(qi)
     scheduleQueueCheck(wasThrottled = false)

--- a/looty/src/main/scala/looty/views/HomeView.scala
+++ b/looty/src/main/scala/looty/views/HomeView.scala
@@ -13,6 +13,9 @@ class HomeView(val banner: String, val version: String) extends View {
 
   def versionHistory = """
 # Version History
+## 0.2.1.77 (2019-11-18)
+Chrome extension works again, hurray
+
 ## 0.2.1.76 (2019-10-30)
 firefox review placation
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -49,11 +49,11 @@ object Build extends sbt.Build {
       val srcDir = (sourceDirectory in Assets).value
       val lessSrcs = (sourceDirectory in Assets).value ** (i -- x)
       val f = lessSrcs.pair(relativeTo(srcDir))
-      f.map(_._2).map(_.replace(".less", ".css"))
+        //path delimiter fix for windows builds in css paths
+        //.replace("\\","/")
+          f.map(_._2).map(_.replace(".less", ".css").replace("\\","/"))
     }
-
     val less = lessFiles.map(f => s"""<link rel="stylesheet" href="$f"/>""").mkString("\n")
-
     val htmlSrcDir: File = (sourceDirectory in Assets).value
     val htmlSrcs: PathFinder = htmlSrcDir * "*.template.html"
     val outDir: File = WebKeys.webTarget.value / "public" / "main"


### PR DESCRIPTION
Woops i see that some other commits hopped here, last 3 should go in.

Welp as simple as that, sad i had to learn it hard way. :)

I'm not sure if you use (https://ssl.google-analytics.com) for anything still , if not we can get rid of it in popup.html also

btw. about browser warnings : 
"unnable to parse Affix ..."
there is 8000+ mods, so warnings about them are "infinite" source of messages, its impossible to add them, or at least to pickup those which are missing from your filter mod groups.

Although 
"unnable to parse property/typeline ..."
are useful to spot missing item types/types etc

P.S.
Can I contact you other way than this pull requests ?

